### PR TITLE
replaces deprecated apiVersion with the latest one

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -115,7 +115,7 @@ If set, the specific test case to run.
 KUTTL test command is the heart of the test harness.  It requires a kuttl-test.yaml which defines the test setup.
 
 ```yaml
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 testDirs:
 - ./test/integration

--- a/content/docs/kuttl-test-harness.md
+++ b/content/docs/kuttl-test-harness.md
@@ -146,7 +146,7 @@ kubectl kuttl test --start-kind=true ./tests/e2e/
 To add this test suite to your project, create a `kuttl-test.yaml` file:
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 testDirs:
 - ./tests/e2e/

--- a/content/docs/testing/reference.md
+++ b/content/docs/testing/reference.md
@@ -9,7 +9,7 @@
 The `TestSuite` object specifies the settings for the entire test suite and should live in the test suite configuration file (`kuttl-test.yaml` by default, or `--config`):
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startKIND: true
 kindContainers:
@@ -44,7 +44,7 @@ kindContainers    | list of strings  | List of Docker images to load into the KI
 The `TestStep` object can be used to specify settings for a test step and can be specified in any test step YAML.
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:
 - apiVersion: v1
@@ -77,7 +77,7 @@ labels     | map    | If specified, a label selector to use when looking up obje
 The `TestAssert` object can be used to specify settings for a test step's assert and must be specified in the test step's assert YAML.
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 30
 ```

--- a/content/docs/testing/steps.md
+++ b/content/docs/testing/steps.md
@@ -55,7 +55,7 @@ spec:
 To delete objects at the beginning of a test step, you can specify object references to delete in your `TestStep` configuration. In a test step file, add a `TestStep` object:
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:
 # Delete a Pod
@@ -85,7 +85,7 @@ The test harness will wait for the objects to be successfully deleted, if they e
 A `TestStep` configuration can also specify commands to run before running the step:
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl apply -f https://raw.githubusercontent.com/kudobuilder/kudo/master/docs/deployment/10-crds.yaml
@@ -97,7 +97,7 @@ If the `namespaced` setting is set, the `--namespace` flag is set to the test st
 It is also possible to use any installed kubectl plugin when calling kubectl commands:
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install zookeeper --skip-instance

--- a/content/docs/testing/test-environments.md
+++ b/content/docs/testing/test-environments.md
@@ -89,7 +89,7 @@ Before running a test suite, it may be necessary to setup the Kubernetes cluster
 Your `kuttl-test.yaml` can specify the settings needed to setup the cluster:
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startControlPlane: true
 testDirs:

--- a/content/docs/testing/tips.md
+++ b/content/docs/testing/tips.md
@@ -16,8 +16,8 @@ docker build -t myimage .
 
 And then in the TestSuite, set:
 
-```
-apiVersion: kudo.dev/v1alpha1
+```yaml
+apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startKIND: true
 kindContainers:
@@ -99,7 +99,7 @@ Note that CRDs created via the `crdDir` test suite configuration are available f
 You can test a Helm chart by installing it in either a test step or your test suite:
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 commands:
 - command: kubectl create serviceaccount -n kube-system tiller
@@ -121,7 +121,7 @@ kindNodeCache: true
 By default, [kind](https://kind.sigs.k8s.io/) does not persist its containerd directory, meaning that on every test run you will have to download all of the images defined in the tests. However, the kuttl test harness supports creating a named Docker volume for each node specified in the kind configuration (or the default node if no nodes or configuration are specified) that will be used for each test run:
 
 ```yaml
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startKIND: true
 kindNodeCache: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
**What this PR does / why we need it**:
Replaces the deprecated `apiVersion: kudo.dev/v1alpha1` to the latest `apiVersion: kuttl.dev/v1beta1`.
The release 0.4 came with an update to the apiVersion for the kuttl tool. But this was not updated in the documentation. This PR fixes that.
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kudobuilder/kuttl/issues/234


