### PR TITLE
Fixes kuttl test command typo

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -43,7 +43,7 @@ Provides general help or help on a specific command
 Print the current KUTTL version.
 :::
 
-::: flag kubectl kudo test
+::: flag kubectl kuttl test
 Run KUTTL test harness.
 :::
 


### PR DESCRIPTION
Signed-off-by: farhan5900 <farhan5900@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Fixes typo in one of the commands on the CLI Usage Page.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #35 

**Special notes for your reviewer**:
NA
